### PR TITLE
pytests typo

### DIFF
--- a/02_03_sw_skills/SW_Skills_Lab-2.ipynb
+++ b/02_03_sw_skills/SW_Skills_Lab-2.ipynb
@@ -117,7 +117,7 @@
     "* Once in the virtual environment, run `pip install -r requirements.txt` to install pytest\n",
     "* There already is a `tests` directory with a single file, `test_shared.py`\n",
     "* It should have one function defined, aside from the imports. `test_shared_string()`\n",
-    "* If properly installed, you should be able to run either `pytests -v tests` at the command line, or alternatively `make test`.\n",
+    "* If properly installed, you should be able to run either `pytest -v tests` at the command line, or alternatively `make test`.\n",
     "* You should see console output indicating one test was run, and that it passed."
    ]
   },


### PR DESCRIPTION
`pytests -v tests` that was supposed to be `pytest -v tests`